### PR TITLE
Uncommented out base controller per heroku app crash

### DIFF
--- a/app/controllers/admin/api/v1/base_controller.rb
+++ b/app/controllers/admin/api/v1/base_controller.rb
@@ -1,4 +1,4 @@
-# class Admin::Api::V1::BaseController < ActionController::API
+class Admin::Api::V1::BaseController < ActionController::API
   # before_action :require_admin!
   #
   # def require_admin!
@@ -16,4 +16,4 @@
   # def four_oh_four
   #   raise ActionController::RoutingError.new('Not Found')
   # end
-# end
+end


### PR DESCRIPTION
- Enabled the class Admin API v1 Base Controller per error message in Heroku logs:
_/app/vendor/bundle/ruby/2.4.0/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:511:in `load_missing_constant': Unable to autoload constant Admin::Api::V1::BaseController, expected /app/app/controllers/admin/api/v1/base_controller.rb to define it (LoadError)_
