### PR TITLE
Adds flash message to bookmark action when a user is logged out

### DIFF
--- a/app/controllers/user_videos_controller.rb
+++ b/app/controllers/user_videos_controller.rb
@@ -13,6 +13,11 @@ class UserVideosController < ApplicationController
     redirect_back(fallback_location: root_path)
   end
 
+  def error
+    flash[:error] = "You must login to bookmark videos."
+    redirect_to login_path
+  end
+
   private
 
   def user_video_params

--- a/app/views/tutorials/show.html.erb
+++ b/app/views/tutorials/show.html.erb
@@ -21,9 +21,9 @@
           <%= button_to "Edit Video", edit_admin_video_path(facade.current_video), method: "get"%>
         <% end %>
         <% if current_user %>
-        <%= button_to "Bookmark", user_videos_path(video_id: facade.current_video.id, user_id: current_user.id), method: :post, class: "btn btn-outline mb1 teal" %>
+          <%= button_to "Bookmark", user_videos_path(video_id: facade.current_video.id, user_id: current_user.id), method: :post, class: "btn btn-outline mb1 teal" %>
         <% else %>
-        <%= link_to "Bookmark", login_path, class: "btn btn-outline mb1 teal" %>
+          <%= button_to "Bookmark", bookmark_error_path, method: :get, class: "btn btn-outline mb1 teal"  %>
         <% end %>
       </div>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,4 +47,5 @@ Rails.application.routes.draw do
   end
 
   resources :user_videos, only:[:create, :destroy]
+  get '/bookmarks', to: "user_videos#error", as: :bookmark_error
 end


### PR DESCRIPTION
Solves Issue #2 -- 

- Adds a flash message after a visitor clicks on 'bookmark' that they must be logged in.
- Attempted to fix this with alternate tools like a tooltip or modal to avoid routing the user away from the in-progress video, but did not have success in achieving the desired result. If we're unhappy with the user flow, we can revisit this in the future.