### PR TITLE
Email confirm

### DIFF
--- a/app/controllers/confirm_controller.rb
+++ b/app/controllers/confirm_controller.rb
@@ -1,0 +1,16 @@
+class ConfirmController < ApplicationController
+
+  def create
+    if current_user.confirm_token == token_params[:token]
+      current_user.update_column(:email_confirmed, true)
+      flash[:success] = "Thank you! Your account is now activated."
+      redirect_to dashboard_path
+    end
+  end
+
+  private
+
+  def token_params
+    params.permit(:token)
+  end
+end

--- a/app/controllers/confirm_controller.rb
+++ b/app/controllers/confirm_controller.rb
@@ -3,8 +3,11 @@ class ConfirmController < ApplicationController
   def create
     if current_user.confirm_token == token_params[:token]
       current_user.update_column(:email_confirmed, true)
-      flash[:success] = "Thank you! Your account is now activated."
+      flash[:success] = 'Thank you! Your account is now activated.'
       redirect_to dashboard_path
+    else
+      flash[:error] = 'Error! That token is not valid.'
+      redirect_to root_path
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -12,6 +12,7 @@ class UsersController < ApplicationController
 
   def create
     @user = User.create(user_params)
+    @user.confirmation_token
     if @user.save
       session[:user_id] = @user.id
       redirect_to dashboard_path
@@ -26,5 +27,4 @@ class UsersController < ApplicationController
   def user_params
     params.require(:user).permit(:email, :first_name, :last_name, :password)
   end
-
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -15,6 +15,8 @@ class UsersController < ApplicationController
     @user.confirmation_token
     if @user.save
       session[:user_id] = @user.id
+      flash[:success] = "Logged in as #{@user.email}."
+      ConfirmMailer.registration_confirmation(@user).deliver_now
       redirect_to dashboard_path
     else
       flash.now[:error] = 'Username already exists'

--- a/app/mailers/confirm_mailer.rb
+++ b/app/mailers/confirm_mailer.rb
@@ -1,0 +1,6 @@
+class ConfirmMailer < ApplicationMailer
+  def registration_confirmation(current_user)
+    @user = current_user
+    mail(to: @user.email, subject: "Confirm Your Turing Tutorials Account!")
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,4 +29,9 @@ class User < ApplicationRecord
     .order('tutorials.id, videos.position')
   end
 
+  def confirmation_token
+    if self.confirm_token.nil?
+      self.confirm_token = SecureRandom.urlsafe_base64.to_s
+    end
+  end
 end

--- a/app/views/confirm_mailer/registration_confirmation.html.erb
+++ b/app/views/confirm_mailer/registration_confirmation.html.erb
@@ -1,1 +1,1 @@
-Visit <a href="http://localhost:3000/confirm?token=<%= @user.confirm_token %>">here</a> to activate your account.
+Visit <a href="https://fast-sea-29858.herokuapp.com/confirm?token=<%= @user.confirm_token %>">here</a> to activate your account.

--- a/app/views/confirm_mailer/registration_confirmation.html.erb
+++ b/app/views/confirm_mailer/registration_confirmation.html.erb
@@ -1,0 +1,1 @@
+Visit <a href="http://localhost:3000/confirm?token=<%= @user.confirm_token %>">here</a> to activate your account.

--- a/app/views/confirm_mailer/registration_confirmation.text.erb
+++ b/app/views/confirm_mailer/registration_confirmation.text.erb
@@ -1,1 +1,1 @@
-Visit <a href="http://localhost:3000/confirm?token=<%= @user.confirm_token %>">here</a> to activate your account.
+Visit <a href="https://fast-sea-29858.herokuapp.com/confirm?token=<%= @user.confirm_token %>">here</a> to activate your account.

--- a/app/views/confirm_mailer/registration_confirmation.text.erb
+++ b/app/views/confirm_mailer/registration_confirmation.text.erb
@@ -1,0 +1,1 @@
+Visit <a href="http://localhost:3000/confirm?token=<%= @user.confirm_token %>">here</a> to activate your account.

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,5 +1,10 @@
 <section class='dashboard-main'>
   <h1> <%= current_user.first_name %>'s Dashboard </h1>
+  <% if current_user.email_confirmed == false %>
+    <span class="flash-message">This account has not yet been activated. Please check your email.</span>
+    <br />
+  <% end %>
+
   <% if current_user.access_token == nil %>
     <%= link_to 'Connect to Github', github_login_path %>
       <br>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,4 +45,6 @@ Rails.application.routes.draw do
 
   resources :user_videos, only:[:create, :destroy]
   get '/bookmarks', to: "user_videos#error", as: :bookmark_error
+
+  get '/confirm', to: 'confirm#create'
 end

--- a/db/migrate/20190517170912_add_email_confirm_column_to_users.rb
+++ b/db/migrate/20190517170912_add_email_confirm_column_to_users.rb
@@ -1,0 +1,6 @@
+class AddEmailConfirmColumnToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :email_confirmed, :boolean, default: false
+    add_column :users, :confirm_token, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_13_144110) do
+ActiveRecord::Schema.define(version: 2019_05_17_170912) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -76,6 +76,8 @@ ActiveRecord::Schema.define(version: 2019_05_13_144110) do
     t.datetime "updated_at", null: false
     t.string "access_token"
     t.string "github_login"
+    t.boolean "email_confirmed", default: false
+    t.string "confirm_token"
     t.index ["email"], name: "index_users_on_email"
   end
 

--- a/spec/features/vistors/visitor_can_register_spec.rb
+++ b/spec/features/vistors/visitor_can_register_spec.rb
@@ -73,7 +73,17 @@ describe 'as a visitor', :vcr, :js do
     expect(user.confirm_token).to be_a(String)
 
     expect(current_path).to eq(dashboard_path)
-    save_and_open_page
+
     expect(page).to have_content("This account has not yet been activated. Please check your email.")
+  end
+
+  it 'allows me to confirm my account' do
+    user = create(:user, confirm_token: "123445689234")
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+    visit "/confirm?token=#{user.confirm_token}"
+
+    expect(current_path).to eq(dashboard_path)
+    expect(user.email_confirmed).to eq(true)
+    expect(page).to have_content("Thank you! Your account is now activated.")
   end
 end

--- a/spec/features/vistors/visitor_can_register_spec.rb
+++ b/spec/features/vistors/visitor_can_register_spec.rb
@@ -71,5 +71,9 @@ describe 'as a visitor', :vcr, :js do
 
     expect(user.email_confirmed).to eq(false)
     expect(user.confirm_token).to be_a(String)
+
+    expect(current_path).to eq(dashboard_path)
+    save_and_open_page
+    expect(page).to have_content("This account has not yet been activated. Please check your email.")
   end
 end

--- a/spec/features/vistors/visitor_can_register_spec.rb
+++ b/spec/features/vistors/visitor_can_register_spec.rb
@@ -74,16 +74,26 @@ describe 'as a visitor', :vcr, :js do
 
     expect(current_path).to eq(dashboard_path)
 
-    expect(page).to have_content("This account has not yet been activated. Please check your email.")
+    expect(page).to have_content('This account has not yet been activated. Please check your email.')
   end
 
   it 'allows me to confirm my account' do
-    user = create(:user, confirm_token: "123445689234")
+    user = create(:user, confirm_token: '123445689234')
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
     visit "/confirm?token=#{user.confirm_token}"
 
     expect(current_path).to eq(dashboard_path)
     expect(user.email_confirmed).to eq(true)
-    expect(page).to have_content("Thank you! Your account is now activated.")
+    expect(page).to have_content('Thank you! Your account is now activated.')
+  end
+
+  it 'will not confirm an account with an invalid token' do
+    user = create(:user, confirm_token: '123445689234')
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+    visit '/confirm?token=12u2o3u4o2u348u2304598298'
+
+    expect(current_path).to eq(root_path)
+    expect(user.email_confirmed).to eq(false)
+    expect(page).to have_content('Error! That token is not valid.')
   end
 end

--- a/spec/features/vistors/visitor_can_register_spec.rb
+++ b/spec/features/vistors/visitor_can_register_spec.rb
@@ -2,12 +2,6 @@ require 'rails_helper'
 
 describe 'as a visitor', :vcr, :js do
   it 'will register a new account' do
-    email = 'jimbob@aol.com'
-    first_name = 'Jim'
-    last_name = 'Bob'
-    password = 'password'
-    password_confirmation = 'password'
-
     visit root_path
 
     click_on 'Sign In'
@@ -18,30 +12,24 @@ describe 'as a visitor', :vcr, :js do
 
     expect(current_path).to eq(new_user_path)
 
-    fill_in 'user[email]', with: email
-    fill_in 'user[first_name]', with: first_name
-    fill_in 'user[last_name]', with: last_name
-    fill_in 'user[password]', with: password
-    fill_in 'user[password_confirmation]', with: password
+    fill_in 'user[email]', with: 'jimbob@aol.com'
+    fill_in 'user[first_name]', with: 'Jim'
+    fill_in 'user[last_name]', with: 'Bob'
+    fill_in 'user[password]', with: 'password'
+    fill_in 'user[password_confirmation]', with: 'password'
 
     click_on'Create Account'
 
     expect(current_path).to eq(dashboard_path)
 
-    expect(page).to have_content(email)
-    expect(page).to have_content(first_name)
-    expect(page).to have_content(last_name)
+    expect(page).to have_content('jimbob@aol.com')
+    expect(page).to have_content('Jim')
+    expect(page).to have_content('Bob')
     expect(page).to_not have_content('Sign In')
   end
 
   it 'will not allow a user to register with an existing email' do
     user = create(:user, email: 'jimbob@aol.com')
-
-    email = 'jimbob@aol.com'
-    first_name = 'Jim'
-    last_name = 'Bob'
-    password = 'password'
-    password_confirmation = 'password'
 
     visit login_path
 
@@ -49,14 +37,39 @@ describe 'as a visitor', :vcr, :js do
 
     expect(current_path).to eq(new_user_path)
 
-    fill_in 'user[email]', with: email
-    fill_in 'user[first_name]', with: first_name
-    fill_in 'user[last_name]', with: last_name
-    fill_in 'user[password]', with: password
-    fill_in 'user[password_confirmation]', with: password
+    fill_in 'user[email]', with: 'jimbob@aol.com'
+    fill_in 'user[first_name]', with: 'Jim'
+    fill_in 'user[last_name]', with: 'Bob'
+    fill_in 'user[password]', with: 'password'
+    fill_in 'user[password_confirmation]', with: 'password'
 
     click_on'Create Account'
 
     expect(page).to have_content('Username already exists')
+  end
+
+  it 'sends an email confirmation token after registration' do
+    visit root_path
+
+    click_on 'Sign In'
+
+    expect(current_path).to eq(login_path)
+
+    click_on 'Sign up now.'
+
+    expect(current_path).to eq(new_user_path)
+
+    fill_in 'user[email]', with: 'jimbob@aol.com'
+    fill_in 'user[first_name]', with: 'Jim'
+    fill_in 'user[last_name]', with: 'Bob'
+    fill_in 'user[password]', with: 'password'
+    fill_in 'user[password_confirmation]', with: 'password'
+
+    click_on'Create Account'
+
+    user = User.last
+
+    expect(user.email_confirmed).to eq(false)
+    expect(user.confirm_token).to be_a(String)
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -37,6 +37,17 @@ RSpec.describe User, type: :model do
 
     end
 
+    describe 'confirmation_token' do
+      it 'updates a users confirm_token' do
+        user = User.create(email: 'user@email.com', password: 'password', first_name:'Jim', role: 0)
+        expect(user.confirm_token).to eq(nil)
+
+        user.confirmation_token
+        expect(user.confirm_token).to_not eq(nil)
+        expect(user.confirm_token).to be_a(String)
+      end
+    end
+
     it 'returns tutorials with bookmarked videos' do
       user = create(:user)
       tutorial= create(:tutorial, title: "I Love Pineapple Pizza")


### PR DESCRIPTION
Solves Issue #7 

- Migrated database to add confirm_token and email_confirmed columns to the user table.
- Added to visitor_can_register_spec test to test that a user receives a confirmation token and email upon registration, and can confirm their email through the link within.
- Added ConfirmMailer with associated routes and email templates.
- Updated user dashboard to show a conditional message that their account has not yet been confirmed.
- Added test & conditional if a user tries to confirm an email with an incorrect token.