### PR TITLE
Removed require-relative and added rubocop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,18 @@
+AllCops:
+  Exclude:
+    - db/**/*
+    - config/**/*
+    - script/**/*
+    - bin/**/*
+    - lib/**/*
+    - spec/**/*
+    - node_modules/**/*
+Naming/MemoizedInstanceVariableName:
+  EnforcedStyleForLeadingUnderscores: optional
+Style/Documentation:
+  Enabled: false
+Style/ClassAndModuleChildren:
+  Enabled: false
+Metrics/LineLength:
+  # Ignore class definitions and comments
+  IgnoredPatterns: ['^class .*','^\s*\# .*']

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -1,5 +1,3 @@
-require_relative '../concerns/controller_helper'
-
 class Admin::BaseController < ApplicationController
   include ControllerHelper
   before_action :require_admin!

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,3 @@
-require_relative './concerns/controller_helper'
-
 class ApplicationController < ActionController::Base
   include ControllerHelper
   helper_method :current_user


### PR DESCRIPTION
Removed require_relative from controllers referencing Controller Helper methods.
Added Rubocob config file to ignore spec, config, bin, lib, node_modules, script and db.